### PR TITLE
Deployability and usability improvements

### DIFF
--- a/build/helm/keylime/charts/keylime-init/templates/ca-job.yaml
+++ b/build/helm/keylime/charts/keylime-init/templates/ca-job.yaml
@@ -44,6 +44,14 @@ spec:
             - /bin/bash
             - -c
             - |
+              ls /usr/local/bin/kubectl
+              if [ $? -ne 0 ]
+              then
+                  pushd /usr/local/bin
+                  curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
+                  chmod +x /usr/local/bin/kubectl
+                  popd
+              fi
               # check if the secrets exist already in which case we'll just respect them
               kubectl get secret $KEYLIME_SECRETS_NAME $KEYLIME_SECRETS_CA_PW_NAME
               if [ $? -eq 0 ] ; then

--- a/build/helm/keylime/charts/keylime-init/templates/tpm-cert-store-job.yaml
+++ b/build/helm/keylime/charts/keylime-init/templates/tpm-cert-store-job.yaml
@@ -42,6 +42,14 @@ spec:
             - /bin/bash
             - -c
             - |
+              ls /usr/local/bin/kubectl
+              if [ $? -ne 0 ]
+              then
+                  pushd /usr/local/bin
+                  curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
+                  chmod +x /usr/local/bin/kubectl
+                  popd
+              fi
               # check if the secrets exist already in which case we'll just respect them
               kubectl get secret $KEYLIME_SECRETS_TPM_CERT_STORE_NAME
               if [ $? -eq 0 ] ; then

--- a/build/helm/keylime/charts/keylime-registrar/templates/deployment.yaml
+++ b/build/helm/keylime/charts/keylime-registrar/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               containerPort: {{ .Values.service.tlsPort }}
               protocol: TCP
           volumeMounts:
-            {{- if .Values.global.database.sqlite.enable }}
+            {{- if and .Values.global.database.sqlite.enable .Values.global.database.sqlite.persistence.registrar.create }}
             - name: db-disk
               mountPath: /var/lib/keylime/
               {{- if .Values.global.database.sqlite.persistence.registrar.subPath }}
@@ -59,7 +59,7 @@ spec:
           secret:
             defaultMode: 420
             secretName: "{{ include "registrar.ca.secret" . }}"
-        {{- if .Values.global.database.sqlite.enable }}
+        {{- if and .Values.global.database.sqlite.enable .Values.global.database.sqlite.persistence.registrar.create }}
         - name: db-disk
           persistentVolumeClaim:
             claimName: "{{ include "registrar.db.pvcName" . }}"

--- a/build/helm/keylime/charts/keylime-verifier/templates/deployment.yaml
+++ b/build/helm/keylime/charts/keylime-verifier/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           volumeMounts:
-            {{- if .Values.global.database.sqlite.enable }}
+            {{- if and .Values.global.database.sqlite.enable .Values.global.database.sqlite.persistence.verifier.create }}
             - name: db-disk
               mountPath: /var/lib/keylime/
               {{- if .Values.global.database.sqlite.persistence.verifier.subPath }}
@@ -56,7 +56,7 @@ spec:
           secret:
             defaultMode: 420
             secretName: "{{ include "verifier.ca.secret" . }}"
-        {{- if .Values.global.database.sqlite.enable }}
+        {{- if and .Values.global.database.sqlite.enable .Values.global.database.sqlite.persistence.verifier.create }}
         - name: db-disk
           persistentVolumeClaim:
             claimName: "{{ include "verifier.db.pvcName" . }}"

--- a/build/helm/keylime/templates/NOTES.txt
+++ b/build/helm/keylime/templates/NOTES.txt
@@ -1,5 +1,10 @@
 ## MANAGEMENT:
 
+{{- if .Values.global.database.postgres.enable }}
+
+WARNING: PostgreSQL database backend for both keylime verifier and registrar still not implemented. Will use a sqlite database instead.
+{{- end }}
+
 To control and manage your keylime installation, you probably want to use the `keylime_tenant` command-line interface.
 {{- if .Values.tags.tenant }}
 

--- a/build/helm/keylime/values.yaml
+++ b/build/helm/keylime/values.yaml
@@ -67,8 +67,8 @@ global:
       persistence:
         # registrar contains all the persistent volume settings for the registrar
         registrar:
-          # create will create persistent volume claims. Use the 'existingClaim' settings below if you set this to false.
-          create: true
+          # create will create persistent volume claims. If this value is set to false (the default), and 'persistence' is still required, use the 'existingClaim' settings below.
+          create: false
           # storageClass of the persisted volume that will be requested
           # Use "-" for an empty storageClass appearance in the PVC which effectively disables dynamic provisioning
           # If the setting below is empty or null, the whole entry will be skipped which enables the default storage provisioner for the PVC
@@ -87,8 +87,8 @@ global:
           subPath: ""
         # verifier contains all the persistent volume settings for the verifier
         verifier:
-          # create will create persistent volume claims. Use the 'existingClaim' settings below if you set this to false.
-          create: true
+          # create will create persistent volume claims. If this value is set to false (the default), and 'persistence' is still required, use the 'existingClaim' settings below.
+          create: false
           # storageClass of the persisted volume that will be requested.
           # Use "-" for an empty storageClass appearance in the PVC which effectively disables dynamic provisioning
           # If the setting below is empty or null, the whole entry will be skipped which enables the default storage provisioner for the PVC


### PR DESCRIPTION
Some minimalistic changes in order to make this helm chart readily functional, out of the box, by a large contingent of users. The idea is to allow one to try it out with something simple, such as `minikube`, with minimal tinkering.

First of all, there is now a very simple set of `curl` commands to grab `kubectl` in case an image which does not have it is used (I do understand that not every Kubernetes environment will give pods direct access to the internet to download, but in this case the deployment would fail anyway)

Second, the "non-persistent" sqlite deployment the default, and everything else (either persistent sqlite or other databases) to be deployed only via a customized set of parameters.

Finally, a have added a warning for non-implemented options, such as postgres database.