### PR TITLE
helm: add option to set custom images from values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,28 @@ global:
     agent:
       privileged: false
 ```
+
+5 - Deploy with custom images (e.g. from a local registry)
+```
+global:
+  service:
+    agent:
+      initImage:
+        repository: localhost/custom-agent-initImage
+        tag: latest
+      image:
+        repository: localhost/custom-agent-image
+        tag: latest
+    registrar:
+      image:
+        repository: localhost/custom-registrar-image
+        tag: latest
+    verifier:
+      image:
+        repository: localhost/custom-verifier-image
+        tag: latest
+    tenant:
+      image:
+        repository: localhost/custom-tenant-image
+        tag: latest
+```

--- a/build/helm/keylime/charts/keylime-agent/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-agent/templates/_helpers.tpl
@@ -84,6 +84,49 @@ Expand to the secret name for the certificate volume to be used
 {{- end }}
 
 {{/*
+Define a custom image repository.
+*/}}
+{{- define "agent.image.repository" -}}
+{{- if .Values.global.service.agent.image.repository }}
+{{- toYaml .Values.global.service.agent.image.repository }}
+{{- else }}
+{{- toYaml .Values.image.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom image tag.
+*/}}
+{{- define "agent.image.tag" -}}
+{{- if .Values.global.service.agent.image.tag }}
+{{- toYaml .Values.global.service.agent.image.tag }}
+{{- else }}
+{{- toYaml .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom init image repository.
+*/}}
+{{- define "agent.initImage.repository" -}}
+{{- if .Values.global.service.agent.initImage.repository }}
+{{- toYaml .Values.global.service.agent.initImage.repository }}
+{{- else }}
+{{- toYaml .Values.initImage.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom init image tag.
+*/}}
+{{- define "agent.initImage.tag" -}}
+{{- if .Values.global.service.agent.initImage.tag }}
+{{- toYaml .Values.global.service.agent.initImage.tag }}
+{{- else }}
+{{- toYaml .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+{{/*
 Decide on a privileged or unprivileged securityContext for a pod
 */}}
 {{- define "agent.secctx" -}}

--- a/build/helm/keylime/charts/keylime-agent/templates/daemonset.yaml
+++ b/build/helm/keylime/charts/keylime-agent/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
                 name: {{ include "keylime.ca.secret.password" . }}
           securityContext:
             {{- toYaml .Values.initSecurityContext | nindent 12 }}
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag | default .Chart.AppVersion }}"
+          image: '{{- include "agent.initImage.repository" . }}:{{- include "agent.initImage.tag" .}}'
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           volumeMounts:
             - name: certs
@@ -90,7 +90,7 @@ spec:
                 name: {{ include "agent.configMap" . }}
           securityContext:
             {{- include "agent.secctx" . | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: '{{- include "agent.image.repository" . }}:{{- include "agent.image.tag" .}}'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: agent

--- a/build/helm/keylime/charts/keylime-agent/values.yaml
+++ b/build/helm/keylime/charts/keylime-agent/values.yaml
@@ -5,16 +5,10 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/keylime/keylime_agent
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
 
 initImage:
-  repository: quay.io/keylime/keylime_tenant
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/build/helm/keylime/charts/keylime-registrar/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-registrar/templates/_helpers.tpl
@@ -131,3 +131,26 @@ Will expand a whole 'storageClassName: <entry>' section, or nothing if the setti
 {{- end }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Define a custom image repository.
+*/}}
+{{- define "registrar.image.repository" -}}
+{{- if .Values.global.service.registrar.image.repository }}
+{{- toYaml .Values.global.service.registrar.image.repository }}
+{{- else }}
+{{- toYaml .Values.image.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom image tag.
+*/}}
+{{- define "registrar.image.tag" -}}
+{{- if .Values.global.service.registrar.image.tag }}
+{{- toYaml .Values.global.service.registrar.image.tag }}
+{{- else }}
+{{- toYaml .Chart.AppVersion }}
+{{- end }}
+{{- end }}

--- a/build/helm/keylime/charts/keylime-registrar/templates/deployment.yaml
+++ b/build/helm/keylime/charts/keylime-registrar/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
                 name: {{ include "registrar.configMap" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: '{{- include "registrar.image.repository" . }}:{{- include "registrar.image.tag" .}}'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: registrar

--- a/build/helm/keylime/charts/keylime-registrar/values.yaml
+++ b/build/helm/keylime/charts/keylime-registrar/values.yaml
@@ -5,10 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/keylime/keylime_registrar
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/build/helm/keylime/charts/keylime-tenant/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-tenant/templates/_helpers.tpl
@@ -93,3 +93,25 @@ Expand to the secret name for the TPM cert store volume to be used
 {{- default (include "keylime.tpmCertStore.secret" .) .Values.global.tpmCertStore.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define a custom image repository.
+*/}}
+{{- define "tenant.image.repository" -}}
+{{- if .Values.global.service.tenant.image.repository }}
+{{- toYaml .Values.global.service.tenant.image.repository }}
+{{- else }}
+{{- toYaml .Values.image.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom image tag.
+*/}}
+{{- define "tenant.image.tag" -}}
+{{- if .Values.global.service.tenant.image.tag }}
+{{- toYaml .Values.global.service.tenant.image.tag }}
+{{- else }}
+{{- toYaml .Chart.AppVersion }}
+{{- end }}
+{{- end }}

--- a/build/helm/keylime/charts/keylime-tenant/templates/deployment.yaml
+++ b/build/helm/keylime/charts/keylime-tenant/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 name: {{ include "keylime.ca.secret.password" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: '{{- include "tenant.image.repository" . }}:{{- include "tenant.image.tag" .}}'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/bash

--- a/build/helm/keylime/charts/keylime-tenant/values.yaml
+++ b/build/helm/keylime/charts/keylime-tenant/values.yaml
@@ -8,10 +8,7 @@ replicaCount: 1
 rustLog: "keylime_agent=info"
 
 image:
-  repository: quay.io/keylime/keylime_tenant
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/build/helm/keylime/charts/keylime-verifier/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-verifier/templates/_helpers.tpl
@@ -131,3 +131,25 @@ Will expand a whole 'storageClassName: <entry>' section, or nothing if the setti
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define a custom image repository.
+*/}}
+{{- define "verifier.image.repository" -}}
+{{- if .Values.global.service.verifier.image.repository }}
+{{- toYaml .Values.global.service.verifier.image.repository }}
+{{- else }}
+{{- toYaml .Values.image.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom image tag.
+*/}}
+{{- define "verifier.image.tag" -}}
+{{- if .Values.global.service.verifier.image.tag }}
+{{- toYaml .Values.global.service.verifier.image.tag }}
+{{- else }}
+{{- toYaml .Chart.AppVersion }}
+{{- end }}
+{{- end }}

--- a/build/helm/keylime/charts/keylime-verifier/templates/statefulset.yaml
+++ b/build/helm/keylime/charts/keylime-verifier/templates/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
                 name: {{ include "verifier.configMap" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: '{{- include "verifier.image.repository" . }}:{{- include "verifier.image.tag" .}}'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: verifier

--- a/build/helm/keylime/charts/keylime-verifier/values.yaml
+++ b/build/helm/keylime/charts/keylime-verifier/values.yaml
@@ -5,10 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/keylime/keylime_verifier
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/build/helm/keylime/values.yaml
+++ b/build/helm/keylime/values.yaml
@@ -130,8 +130,16 @@ global:
       password: ""
   # sevice configure the keylime service (registrar and verifier) that you want to use
   service:
+    # tenant options
+    tenant:
+      # Default image is the from quay, default tag is tag the chart appVersion
+      image:
+        repository: quay.io/keylime/keylime_tenant
     # registrar options
     registrar:
+      # Default image is the from quay, default tag is tag the chart appVersion
+      image:
+        repository: quay.io/keylime/keylime_registrar
       # number of replicas, with default 1. IMPORTANT: if "sqlite" database backend is selected, then this value will be ignored and 1 will be used instead
       replicas: 1
       # type of service, with "ClusterIP" as default. Switch to "NodePort" or "LoadBalancer" to allow
@@ -139,6 +147,9 @@ global:
       type: "ClusterIP"
     # verifier options  
     verifier:
+      # Default image is the from quay, default tag is tag the chart appVersion
+      image:
+        repository: quay.io/keylime/keylime_verifier
       #  number of replicas, with default 1. IMPORTANT: if "sqlite" database backend is selected, then this value will be ignored and 1 will be used instead
       replicas: 1
       # type of service, with "ClusterIP" as default. Switch to "NodePort" or "LoadBalancer" to allow
@@ -146,6 +157,11 @@ global:
       type: "ClusterIP"
     # agent options
     agent:
+      # Default image is the from quay, default tag is tag the chart appVersion
+      initImage:
+        repository: quay.io/keylime/keylime_tenant
+      image:
+        repository: quay.io/keylime/keylime_agent
       # set privileged to "false" in order to deploy unprivileged pods on the agent DaemonSet. IMPORT, it will required Kubernets 1.26 and https://github.com/githedgehog/k8s-tpm-device-plugin
       privileged: true 
 mysql:


### PR DESCRIPTION
Sometimes it's useful to use custom images for the services, e.g. when testing new keylime features from a private repo.

This PR makes the image "repository" and "tag" easily modifiable from the input yaml file.