### PR TITLE
keylime-agent: refine unprivileged mode by adding device plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,37 @@ global:
 
 4 - Deploy agents with unprivileged pods
 ```
+tags:
+  agent: true
+
+global:
+  service:
+    agent:
+      privileged: true
+```
+
+5 - Deploy agents with unprivileged pods
+
+```
+tags:
+  agent: true
+
 global:
   service:
     agent:
       privileged: false
+
+keylime-agent:
+  unprivsecurityContext:
+    readOnlyRootFilesystem: true
+    privileged: false
+    capabilities:
+      drop:
+      - ALL
+    runAsGroup: 109    <---- make this match the group ID of group <tss> on the hosts running the agent.
 ```
 
-5 - Deploy with custom images (e.g. from a local registry)
+6 - Deploy with custom images (e.g. from a local registry)
 ```
 global:
   service:

--- a/build/helm/keylime/charts/keylime-agent/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-agent/templates/_helpers.tpl
@@ -51,6 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+device plugin selector labels
+*/}}
+{{- define "agentplugin.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent.name" . }}-plugin
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "agent.serviceAccountName" -}}
@@ -126,6 +134,30 @@ Define a custom init image tag.
 {{- toYaml .Chart.AppVersion }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define a custom plugin image repository.
+*/}}
+{{- define "agent.pluginImage.repository" -}}
+{{- if .Values.global.service.agent.pluginImage.repository }}
+{{- toYaml .Values.global.service.agent.pluginImage.repository }}
+{{- else }}
+{{- toYaml .Values.pluginImage.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a custom plugin image tag.
+*/}}
+{{- define "agent.pluginImage.tag" -}}
+{{- if .Values.global.service.agent.pluginImage.tag }}
+{{- toYaml .Values.global.service.agent.pluginImage.tag }}
+{{- else }}
+{{- toYaml .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+
 {{/*
 Decide on a privileged or unprivileged securityContext for a pod
 */}}

--- a/build/helm/keylime/charts/keylime-agent/templates/daemonset.yaml
+++ b/build/helm/keylime/charts/keylime-agent/templates/daemonset.yaml
@@ -22,8 +22,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           env:
@@ -46,6 +44,8 @@ spec:
             - name: cvca-certs
               mountPath: /keylime/cv_ca/
               readOnly: true
+            - name: tmpfs
+              mountPath: /tmp
           command:
             - /bin/bash
             - -c
@@ -64,6 +64,7 @@ spec:
               # copy them to the expected destinations
               cp -v /tmp/cv_ca/${POD_IP}-private.pem /certs/server-private.pem
               cp -v /tmp/cv_ca/${POD_IP}-cert.crt /certs/server-cert.crt
+
       containers:
         - name: {{ .Chart.Name }}
           env:
@@ -107,6 +108,9 @@ spec:
               mountPath: /var/lib/keylime-persistent
             - name: secure
               mountPath: /var/lib/keylime/secure
+              readOnly: true
+            - name: tmpfs
+              mountPath: /tmp
             - name: securityfs
               mountPath: /sys/kernel/security
               readOnly: true
@@ -133,6 +137,9 @@ spec:
           secret:
             defaultMode: 420
             secretName: "{{ include "agent.cvca.secret" . }}"
+        - name: tmpfs
+          emptyDir: {}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -145,3 +152,63 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+{{ if not .Values.global.service.agent.privileged }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "agent.fullname" . }}-devplugin
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "agentplugin.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "agentplugin.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}-devplugin
+          image: '{{- include "agent.pluginImage.repository" . }}:{{- include "agent.pluginImage.tag" .}}'
+          imagePullPolicy: {{ .Values.pluginImage.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+          - name: device-plugins
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugins
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ end }}

--- a/build/helm/keylime/charts/keylime-agent/values.yaml
+++ b/build/helm/keylime/charts/keylime-agent/values.yaml
@@ -7,6 +7,9 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
 
+pluginImage:
+  pullPolicy: IfNotPresent
+
 initImage:
   pullPolicy: IfNotPresent
 
@@ -25,19 +28,17 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
-
+# security context for unprivileged containers (default)
 unprivsecurityContext:
+  privileged: false
   capabilities:
     drop:
     - ALL
   readOnlyRootFilesystem: true
 
+# security context for privileged containers
 privsecurityContext:
   privileged: true
-
-initSecurityContext: {}
 
 # Technically the agent does not have a Kubernetes service, however, it also runs a "service".
 # We just leverage the service field here because this is where most people would expect to search for port changes.

--- a/build/helm/keylime/values.yaml
+++ b/build/helm/keylime/values.yaml
@@ -162,8 +162,13 @@ global:
         repository: quay.io/keylime/keylime_tenant
       image:
         repository: quay.io/keylime/keylime_agent
-      # set privileged to "false" in order to deploy unprivileged pods on the agent DaemonSet. IMPORT, it will required Kubernets 1.26 and https://github.com/githedgehog/k8s-tpm-device-plugin
-      privileged: true 
+      # the device plugin image is used when deploying unprivileged agents
+      pluginImage:
+        repository: ghcr.io/keylime/k8s-tpm-device-plugin
+        tag: v0.1.0-1-g0af8e82
+      # Set privileged to "false" in order to deploy unprivileged pods on the agent DaemonSet.
+      # Unprivileged setting will require Kubernetes 1.26 (support for the device plugin API)
+      privileged: false
 mysql:
   auth:
     existingSecret: "{{ .Release.Name }}-keylime-mysql-password"


### PR DESCRIPTION
Adding the newly moved and published keylime/tpm-device-plugin as an option to the helm deployment. Triggered by a single value (asking for unprivileged containers).

There are three unsolved problems this PR does not address.

* The TSS group ID has to be specified by value in `values.yml` during deployment, as kube has no way of guessing it and will not accept symbolic values. My next PR will be more extensive documentation to deal with this problem.

* the reading of MBA and IMA logs is not yet resolved in the keylime agent (running in unprivileged mode). From what we can tell the rust agent will need a change to accommodate this problem (https://github.com/keylime/rust-keylime/issues/657). 

* While the device plugin now allows the specification of MBA and IMA locations in environment variables, we are not using those values in this PR. I have also omitted a bunch of creature comforts present in the original helm chart for the device plugin; they can be retrofitted later, but I wanted to keep this PR as minimal as can be. Use it now, fix up the technical debt l8r.