### PR TITLE
Add required 'serviceName' to keylime-verifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ all: helm
 
 ##@ Build
 
-helm: helm-keylime ## Builds all helm charts
+helm: helm-build ## Builds all helm charts
 
 .PHONY: helm-clean
 helm-clean: helm-keylime-clean ## Cleans all packaged helm charts

--- a/build/helm/keylime/charts/keylime-verifier/templates/statefulset.yaml
+++ b/build/helm/keylime/charts/keylime-verifier/templates/statefulset.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "verifier.selectorLabels" . | nindent 6 }}
+  serviceName: '{{- include "verifier.fullname" . }}'
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/hack/k8s-poc/templates/verifier.yaml.in
+++ b/hack/k8s-poc/templates/verifier.yaml.in
@@ -11,6 +11,7 @@ spec:
       app: keylime
       role: verifier
   replicas: REPLACE_KEYLIME_VERIFIER_REPLICAS
+  serviceName: "keylime-verifier"
   template:
     metadata:
       labels:


### PR DESCRIPTION
From the Kubernetes OpenAPI specification [1], the 'serviceName' field is required for a StatefulSet.

[1] https://github.com/kubernetes/kubernetes/blob/afe4c041f392701da0a8bfd814dc19ed9ff32e56/api/openapi-spec/swagger.json