### PR TITLE
added external MySQL db support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ global:
       enable: true
 ```
 
+### Registrars and verifiers: using an external mysql server
+
+An external managed MySQL database can be used also for the `verifier` and `registrar`:
+
+```
+global:
+  database:
+    mysql:
+      external: true
+mysql:
+  auth:
+    externalIP: "10.103.4.2"
+    externalUser: "keylime"
+    externalPassword: "TikBue7mQS"
+```
+
 ### Registars and verifiers: overriding site specifig configuration
 
 

--- a/build/helm/keylime/charts/keylime-registrar/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-registrar/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Expand to the name of the config map to be used
 {{- if .Values.global.configmap.create }}
 {{- include "keylime.configMap" . }}
 {{- else }}
-{{- default (include "keylime.configMap" .) .Values.global.configmap.registrarName }}meah
+{{- default (include "keylime.configMap" .) .Values.global.configmap.registrarName }}
 {{- end }}
 {{- end }}
 

--- a/build/helm/keylime/templates/configmap.yaml
+++ b/build/helm/keylime/templates/configmap.yaml
@@ -6,11 +6,15 @@ metadata:
   labels:
     {{- include "keylime.labels" . | nindent 4 }}
 data:
-
-{{- if .Values.global.database.mysql.enable }}
+{{- if or .Values.global.database.mysql.enable .Values.global.database.mysql.external }}
+  {{- if .Values.global.database.mysql.external }}  
+  KEYLIME_REGISTRAR_DATABASE_URL: "mysql+pymysql://{{ .Values.mysql.auth.externalUser }}:{{ .Values.mysql.auth.externalPassword }}@{{ .Values.mysql.auth.externalIP }}:3306/{{ .Values.mysql.auth.database }}?charset=utf8"
+  KEYLIME_VERIFIER_DATABASE_URL: "mysql+pymysql://{{ .Values.mysql.auth.externalUser }}:{{ .Values.mysql.auth.externalPassword }}@{{ .Values.mysql.auth.externalIP }}:3306/{{ .Values.mysql.auth.database }}?charset=utf8"
+  {{- else }}
   {{- $mysqlPassword := printf "%s" (include "keylime.mysql.secret.passwordcontents" .) | replace "\"" "" | b64dec }}
   KEYLIME_REGISTRAR_DATABASE_URL: "mysql+pymysql://root:{{ $mysqlPassword }}@{{ template "mysql.primary.fullname" ( index .Subcharts "mysql" ) }}.{{ .Release.Namespace }}.svc.cluster.local:3306/{{ .Values.mysql.auth.database }}?charset=utf8"
   KEYLIME_VERIFIER_DATABASE_URL: "mysql+pymysql://root:{{ $mysqlPassword }}@{{ template "mysql.primary.fullname" ( index .Subcharts "mysql" ) }}.{{ .Release.Namespace }}.svc.cluster.local:3306/{{ .Values.mysql.auth.database }}?charset=utf8"
+  {{- end }}
 {{- end }}
 
 {{- if .Values.tags.agent }}

--- a/build/helm/keylime/values.yaml
+++ b/build/helm/keylime/values.yaml
@@ -123,11 +123,13 @@ global:
       enable: false
     # mysql enables a MySQL database backend
     mysql:
-      # enable activates the PostgreSQL database backend
+      # enable activates the MySQL database backend
       # This will pull in a MySQL helm chart for deployment.
       enable: false
       # leave it empty, and a new password, maintained accross multiple upgrades, will be generated
       password: ""
+      # external to use an external MySQL database instead of using the MySQL helm chart. enable must be false.
+      external: false
   # sevice configure the keylime service (registrar and verifier) that you want to use
   service:
     # tenant options
@@ -173,3 +175,6 @@ mysql:
   auth:
     existingSecret: "{{ .Release.Name }}-keylime-mysql-password"
     database: "keylimedb"
+    externalIP: ""
+    externalUser: ""
+    externalPassword: ""


### PR DESCRIPTION
Allow to pass the IP, username and password for an external managed DB to the chart. Useful for all K8S environments where a managed MySQL service is offered, GC, Azure, AWS, ...