### PR TITLE
added load balancer IP + ressource support

### DIFF
--- a/build/helm/keylime/charts/keylime-registrar/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-registrar/templates/_helpers.tpl
@@ -107,6 +107,17 @@ Select the service type, based on the value set on the "service" section of glob
 {{- end }}
 
 {{/*
+Select the load balancer IP, based on the value set on the "service" section of global values 
+*/}}
+{{- define "registrar.loadBalancerIP" -}}
+{{- if .Values.global.service.registrar.loadBalancerIP }}
+{{- .Values.global.service.registrar.loadBalancerIP }}
+{{- else }}
+{{- .Values.service.loadBalancerIP }}
+{{- end }}
+{{- end }}
+
+{{/*
 Expands to the PVC name of the database disk
 */}}
 {{- define "registrar.db.pvcName" -}}

--- a/build/helm/keylime/charts/keylime-registrar/templates/service.yaml
+++ b/build/helm/keylime/charts/keylime-registrar/templates/service.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "registrar.labels" . | nindent 4 }}
 spec:
   type: {{ include "registrar.serviceType" . }}
+  {{- if and (eq (include "registrar.serviceType" .) "LoadBalancer") (not (empty (include "registrar.loadBalancerIP" . ))) }}
+  loadBalancerIP: {{ include "registrar.loadBalancerIP" . }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.nontlsPort }}
       targetPort: {{ .Values.service.nontlsPort }}

--- a/build/helm/keylime/charts/keylime-registrar/values.yaml
+++ b/build/helm/keylime/charts/keylime-registrar/values.yaml
@@ -37,6 +37,7 @@ service:
   type: ClusterIP
   nontlsPort: 8890
   tlsPort: 8891
+  loadBalancerIP: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/build/helm/keylime/values.yaml
+++ b/build/helm/keylime/values.yaml
@@ -145,7 +145,9 @@ global:
       # type of service, with "ClusterIP" as default. Switch to "NodePort" or "LoadBalancer" to allow
       # components external to the cluster to access the service
       type: "ClusterIP"
-    # verifier options  
+      # the load balancer IP to use if the type is "LoadBalancer"
+      loadBalancerIP: ""
+    # verifier options
     verifier:
       # Default image is the from quay, default tag is tag the chart appVersion
       image:


### PR DESCRIPTION
This addresses the following 2 needs:

- a load balancer IP must be defined in a cloud environment which is static to have the same IP also when the chart is redeployed. Otherwise the cloud provider is assigning a random IP from a pool.
- resource requirements must be configurable from the values.yaml file. Patching the `values.yaml` in the sub charts of registrar and verifier or tenant is not trivial for standard users and make the result not in sync with the main repo. Using default values is causing in rather high resource values. E.g. GC is using 1 cpu and 2 Gi memory which is becoming expensive or is insufficient.