### PR TITLE
support for config values in init

### DIFF
--- a/build/helm/keylime/charts/keylime-init/templates/ca-job.yaml
+++ b/build/helm/keylime/charts/keylime-init/templates/ca-job.yaml
@@ -45,6 +45,12 @@ spec:
                   key: KEYLIME_CA_PASSWORD
             - name: KEYLIME_SECRETS_CA_PW_NAME
               value: "{{ include "keylime.ca.secret.password" . }}"
+            {{- if .Values.global.configmap.configParams }}
+            {{- range $k, $v := .Values.global.configmap.configParams }}
+            - name: {{ $k }}
+              value: {{ $v }}
+            {{- end }}
+            {{- end}}
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
When running the init job the config values are not considered. This results in using default values when creating the certs which is not expected. E.g. `KEYLIME_CA_CERT_CA_NAME`,  `KEYLIME_CA_CERT_CRL_DIST`, ... are all not the ones defined.