### PR TITLE
ao configmap: fixes for handling boolean and numeric values

### DIFF
--- a/build/helm/keylime/charts/keylime-init/templates/ca-job.yaml
+++ b/build/helm/keylime/charts/keylime-init/templates/ca-job.yaml
@@ -48,7 +48,7 @@ spec:
             {{- if .Values.global.configmap.configParams }}
             {{- range $k, $v := .Values.global.configmap.configParams }}
             - name: {{ $k }}
-              value: {{ $v }}
+              value: "{{ $v }}"
             {{- end }}
             {{- end}}
           command:

--- a/build/helm/keylime/templates/configmap.yaml
+++ b/build/helm/keylime/templates/configmap.yaml
@@ -37,7 +37,9 @@ data:
   KEYLIME_TENANT_VERIFIER_PORT: "{{ default "8881" .Values.verifier.service.port }}"
 {{- end }}
 {{- if .Values.global.configmap.configParams }}
-{{- toYaml .Values.global.configmap.configParams | nindent 2 }}
+{{- range $k, $v := .Values.global.configmap.configParams }}
+  {{ $k }} : "{{ $v }}"
+{{- end }}
 {{- end}}
   KEYLIME_VERIFIER_IP: "0.0.0.0"
   KEYLIME_VERIFIER_PORT: "{{ default "8881" .Values.verifier.service.port }}"


### PR DESCRIPTION
Summary
---
This is a small fix to allow the helm-generated configmap to accommodate boolean and numeric values -- it forces extra quotes into the configmap.

How to produce the error
---
The following snippet in `values.yaml` will cause helm deployment failure. It does not matter whether the word `false` is quoted, doublequoted, escaped in any way -- as long as it's recognizable as a boolean the failure will happen.

Similar problems happen with any value that is JSON/YAML parseable as an integer.

```
global:
  configmap:
    configParams:
      KEYLIME_TENANT_REQUIRE_EK_CERT: false
```

Gist of the fix
---
Produce extra quotes in the configmap template[s] to prevent parsing of affected values as anything but string.

Affected locations
---
Two places I noticed that are using `.Values.global.configmap.configParams`:
* `charts/keylime-init/templates/ca-job.yaml` -- global environment variables used to direct CA generation
* `templates/configmap.yaml` -- the actual copying of environment variables into the keylime configmap

Why we need this
---
I cannot start to produce meaningful CI tests without disabling EK cert requirements on AWS machines (since AWS TPMs don't have EK certificates). Expect a second, much larger PR for meaningful CI tests with AWS EC2 VMs as soon as this is merged.