### PR TITLE
CI: typo fixes in scripting system. 

### DIFF
--- a/ci/tests/1_simpletest/runtest.sh
+++ b/ci/tests/1_simpletest/runtest.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+bindir=$(dirname $(realpath $0))
+cd ${bindir}/../../..
+
 . ci/util/util_ao.sh
 
 ao_build      . || exit -1
 ao_clean      . || exit -1
-ao_deploy     . ${PWD}/ci/tests/1_simpletest/values.yml || exit -1
+ao_deploy     . ${bindir}/values.yml || exit -1
 ao_wait       . || exit -1
 ao_simpletest . || exit -1
 ao_clean      .

--- a/ci/tests/2_privilegedagent/runtest.sh
+++ b/ci/tests/2_privilegedagent/runtest.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+bindir=$(dirname $(realpath $0))
+cd ${bindir}/../../..
+
 . ci/util/util_ao.sh
 
 ao_build      . || exit -1
 ao_clean      . || exit -1
-ao_deploy     . ${PWD}/ci/tests/2_privilegedagent/values.yml || exit -1
+ao_deploy     . ${bindir}/values.yml || exit -1
 ao_wait       . || exit -1
 ao_simpletest . || exit -1
 ao_clean      .

--- a/ci/tests/runtests.sh
+++ b/ci/tests/runtests.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+fullpath=$(realpath $0)
+testdir=$(dirname $fullpath)
 passed=0
 failed=0
 total=0
-for test in `find tests -name runtest.sh -type f | sort`
+for test in `find ${testdir} -name runtest.sh -type f | sort`
 do
-    testdir=$(dirname ${test})
-    echo "RUNNING TEST: ${testdir}"
-    echo "---------------------"
+    testname=$(printf "%-20.20s" $(basename $(dirname $test)))
+    echo "+-----------------------------------+"
+    echo "| RUNNING TEST: ${testname}|"
+    echo "+-----------------------------------+"
     if ${test}
     then
         passed=$((passed+1))


### PR DESCRIPTION
The typo prevented tests from being actually run (although the CI currently exercises every other part of the setup, including creating and demolishing EC2 VMs, setting up minikube.

Also prettified some of the output (I could not resist).