### PR TITLE
Include version for keylime-controller chart

### DIFF
--- a/build/helm/keylime/Chart.yaml
+++ b/build/helm/keylime/Chart.yaml
@@ -72,6 +72,7 @@ dependencies:
       - child: service
         parent: verifier.service
   - name: keylime-controller
+    version: "0.1.0"
     tags:
       - controller
   - name: mysql


### PR DESCRIPTION
This change allows fixing compilation issue being
dumped when executing `make helm-keylime` rule:
...
Error: dependency "keylime-controller" has an invalid version/constraint format: improper constraint:
...

Resolves: #56