### PR TITLE
small fixes to make helm build more resilient

### DIFF
--- a/build/helm/keylime-controller/templates/metrics-service.yaml
+++ b/build/helm/keylime-controller/templates/metrics-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "keylime-controller.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "keylime-controller.fullname" . }}-metrics-service
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: attestation-operator

--- a/build/helm/keylime/Chart.yaml
+++ b/build/helm/keylime/Chart.yaml
@@ -72,6 +72,7 @@ dependencies:
       - child: service
         parent: verifier.service
   - name: keylime-controller
+    version: "0.1.0"
     tags:
       - controller
   - name: mysql

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: service
-    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/instance: metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: attestation-operator
     app.kubernetes.io/part-of: attestation-operator
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: metrics-service
   namespace: system
 spec:
   ports:


### PR DESCRIPTION
The following small fixes were required to build the helm chart successfully on an Ubuntu 22.04 machine with helm 3.11.3:

* The main chart referring to the controller has to have a version number (added "0.1.0")
* The metrics service had to have its name shortened to fit into the required 64 character limit.

With the fixes, the helm chart builds and deploys correctly (not tested with the controller, that's subject for a next PR)

Test protocol for reproducing the problems this PR claims to fix:
---
* Ubuntu 22.04 host, helm v3.11.3
* Checkout the current main branch of attestation operator
* `make helm-clean` followed by `make helm` to ensure a clean environment
* `make helm-keylime-deploy` to test the built chart
* `values.yaml` is mostly indifferent, corresponds to the first default in the README