### PR TITLE
helm deploy: controller defaults changed

### DIFF
--- a/build/helm/keylime-controller/templates/deployment.yaml
+++ b/build/helm/keylime-controller/templates/deployment.yaml
@@ -90,4 +90,4 @@ spec:
       - name: tpm-cert-store
         secret:
           defaultMode: 420
-          secretName: keylime-swtpm-cert-store
+          secretName: hhkl-keylime-tpm-cert-store

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -44,4 +44,4 @@ spec:
         - name: tpm-cert-store
           secret:
             defaultMode: 420
-            secretName: keylime-swtpm-cert-store
+            secretName: hhkl-keylime-tpm-cert-store

--- a/config/helm/manager_config_patch.yaml
+++ b/config/helm/manager_config_patch.yaml
@@ -44,4 +44,4 @@ spec:
         - name: tpm-cert-store
           secret:
             defaultMode: 420
-            secretName: keylime-swtpm-cert-store
+            secretName: hhkl-keylime-tpm-cert-store


### PR DESCRIPTION
Changed the defaults for the controller helm deployment to match the secret names that are defined by the rest of the keylime deployment. 

This allows the seamless deployment of the AO controller with the same helm methods.