### PR TITLE
Create appropriate role/rolebinding for tenant in OpenShift

### DIFF
--- a/build/helm/keylime/charts/keylime-tenant/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-tenant/templates/_helpers.tpl
@@ -126,3 +126,17 @@ Define a custom image pullpolicy.
 {{- toYaml .Values.image.pullPolicy }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the role to use
+*/}}
+{{- define "tenant.roleName" -}}
+{{- default (include "tenant.fullname" .) .Values.role.name }}
+{{- end }}
+
+{{/*
+Create the name of the role binding to use
+*/}}
+{{- define "tenant.roleBindingName" -}}
+{{- default (include "tenant.fullname" .) .Values.roleBinding.name }}
+{{- end }}

--- a/build/helm/keylime/charts/keylime-tenant/templates/role.yaml
+++ b/build/helm/keylime/charts/keylime-tenant/templates/role.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.global.openshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tenant.roleName" . }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - anyuid
+  verbs:
+  - use
+{{ end }}

--- a/build/helm/keylime/charts/keylime-tenant/templates/rolebinding.yaml
+++ b/build/helm/keylime/charts/keylime-tenant/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.global.openshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tenant.roleBindingName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{  include "tenant.roleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tenant.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/build/helm/keylime/charts/keylime-tenant/values.yaml
+++ b/build/helm/keylime/charts/keylime-tenant/values.yaml
@@ -50,3 +50,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+role:
+  name: ""
+roleBinding:
+  name: ""


### PR DESCRIPTION
When running in OpenShift, tenant cointainer
is dumping errors when being started. This fix
sets appropriate role and rolebinding to use
anyuid service account only for OpenShift deployment

Resolves: #73