### PR TITLE
[DO NOT MERGE] Role bindings, service accounts, [openshift] security context constraints for keylime agents

### DIFF
--- a/build/helm/keylime/charts/keylime-agent/templates/_helpers.tpl
+++ b/build/helm/keylime/charts/keylime-agent/templates/_helpers.tpl
@@ -70,6 +70,20 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the role to use
+*/}}
+{{- define "agent.roleName" -}}
+{{- default (include "agent.fullname" .) .Values.role.name }}
+{{- end }}
+
+{{/*
+Create the name of the role binding to use
+*/}}
+{{- define "agent.roleBindingName" -}}
+{{- default (include "agent.fullname" .) .Values.roleBinding.name }}
+{{- end }}
+
+{{/*
 Expand to the name of the config map to be used
 */}}
 {{- define "agent.configMap" -}}

--- a/build/helm/keylime/charts/keylime-agent/templates/daemonset.yaml
+++ b/build/helm/keylime/charts/keylime-agent/templates/daemonset.yaml
@@ -8,6 +8,9 @@ spec:
   selector:
     matchLabels:
       {{- include "agent.selectorLabels" . | nindent 6 }}
+  {{- if .Values.serviceAccount.create -}}
+  serviceAccountName: {{ include "agent.serviceAccountName" . }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -21,7 +24,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.create -}}
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           env:
@@ -167,6 +172,7 @@ spec:
   selector:
     matchLabels:
       {{- include "agentplugin.selectorLabels" . | nindent 6 }}
+  serviceAccountName: {{ include "agent.serviceAccountName" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/build/helm/keylime/charts/keylime-agent/templates/role.yaml
+++ b/build/helm/keylime/charts/keylime-agent/templates/role.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.global.openshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agent.roleName" . }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+{{ if .Values.global.service.agent.privileged }}
+  - privileged
+{{ else }}
+  - hostmount-anyuid
+{{ end }}
+  verbs:
+  - use
+{{ end }}

--- a/build/helm/keylime/charts/keylime-agent/templates/rolebinding.yaml
+++ b/build/helm/keylime/charts/keylime-agent/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.global.openshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agent.roleBindingName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agent.roleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/build/helm/keylime/charts/keylime-agent/values.yaml
+++ b/build/helm/keylime/charts/keylime-agent/values.yaml
@@ -29,6 +29,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+role:
+  name: ""
+roleBinding:
+  name: ""
+
 podAnnotations: {}
 
 # command (and args) for regular operation


### PR DESCRIPTION
This is the initial commit. It's not ready to merge.

Only works for OCP when agents are in privileged mode (have not found the correct SCC for unprivileged agents).

Still unsolved is the exact group matching in kubernetes for unprivileged containers.